### PR TITLE
LocaleTracker: Add null check before accessing WifiManager

### DIFF
--- a/src/java/com/android/internal/telephony/LocaleTracker.java
+++ b/src/java/com/android/internal/telephony/LocaleTracker.java
@@ -408,8 +408,11 @@ public class LocaleTracker extends Handler {
             // Set the country code for wifi. This sets allowed wifi channels based on the
             // country of the carrier we see. If we can't see any, reset to 0 so we don't
             // broadcast on forbidden channels.
-            ((WifiManager) mPhone.getContext().getSystemService(Context.WIFI_SERVICE))
-                    .setCountryCode(countryIso);
+            WifiManager wifiManager =
+                    (WifiManager) mPhone.getContext().getSystemService(Context.WIFI_SERVICE);
+            if (wifiManager != null) {
+                wifiManager.setCountryCode(countryIso);
+            }
         }
     }
 


### PR DESCRIPTION
 * WiFi service is not considered as a core service so it won't start in
   min framework, but LocaleTracker accesses to WiFi service's API.
   This would lead to a fatal exception and trigger RescueParty.
 * Add null check before accessing WifiManager to avoid the crash.

Change-Id: Ib1e9aef5a34cb8cfc33f7aa6f242807bc6ef2c46